### PR TITLE
Refactor: [EVER-89] ubti API 질문 결과 분리

### DIFF
--- a/chatbot-server/app/api/ubti.py
+++ b/chatbot-server/app/api/ubti.py
@@ -1,15 +1,18 @@
-from app.schemas.ubti import UBTIRequest
+from typing import AsyncGenerator
+from fastapi import APIRouter, HTTPException
+from fastapi.responses import StreamingResponse
+from typing import Union
+from app.schemas.ubti import UBTIRequest, UBTIQuestion, UBTIComplete, UBTIResult
 from app.utils.redis_client import get_session, save_session, delete_session
 from app.prompts.ubti_prompt import get_ubti_prompt
 from app.db.ubti_types_db import get_all_ubti_types
 from app.db.plan_db import get_all_plans
-from fastapi import APIRouter
-from fastapi.responses import StreamingResponse
 from app.utils.langchain_client import get_chat_model
+import json
+import asyncio
 
 router = APIRouter()
 
-# 검사용 질문 목록 (하나의 질문에 하나씩 답변해야함)
 UBTI_QUESTIONS = [
     "하루 동안 스마트폰을 가장 많이 쓰는 시간대는 언제인가요?",
     "데이터는 주로 어떤 활동에 사용하시나요? (예: 영상, SNS, 웹서핑 등)",
@@ -17,50 +20,63 @@ UBTI_QUESTIONS = [
     "통신비 예산은 어느 정도가 적절하다고 생각하시나요?"
 ]
 
-@router.post("/ubti")
-async def ubti_chat(req: UBTIRequest):
+@router.post(
+    "/ubti/question",
+    summary="다음 UBTI 질문 스트리밍 또는 완료 안내",
+    response_model=Union[UBTIQuestion, UBTIComplete]
+)
+async def next_question(req: UBTIRequest):
     session_id = f"ubti_session:{req.session_id}"
     session = get_session(session_id)
 
     if not session:
-        session_data = {"step": 0, "answers": []}
-        save_session(session_id, session_data)
-        return {"question": UBTI_QUESTIONS[0], "step": 0}
-
-    session["answers"].append(req.message)
-    session["step"] += 1
-
-    if session["step"] < len(UBTI_QUESTIONS):
+        session = {"step": 0, "answers": []}
         save_session(session_id, session)
-        return {"question": UBTI_QUESTIONS[session["step"]], "step": session["step"]}
-    else:
-        answers = session["answers"]
-        delete_session(session_id)
 
-        # UBTI 유형 정보 불러오기
-        ubti_types = get_all_ubti_types()
-        ubti_text = "\n".join([
-            f"{u.emoji} **{u.code} ({u.name})**  - {u.description}" for u in ubti_types
-        ])
+    # 답변이 왔다면 저장하고 step 증가
+    if req.message is not None:
+        session["answers"].append(req.message)
+        session["step"] += 1
+        save_session(session_id, session)
 
-        # 요금제 정보 참조
-        plans = get_all_plans()
-        plans_text = "\n".join([
-            f"- {p.name} / {p.price}원 / {p.data or '-'} / {p.speed or '-'} / 공유:{p.share_data or '-'} / 통화:{p.voice or '-'} / 문자:{p.sms or '-'}"
-            for p in plans
-        ])
+    step = session["step"]
 
-        # 프롬프트 생성
-        prompt = get_ubti_prompt().format(
-            message="\n".join(answers),
-            ubti_types=ubti_text,
-            plans=plans_text
-        )
+    # 질문 완료 시 완료 안내 반환 (200 OK)
+    if step >= len(UBTI_QUESTIONS):
+        return UBTIComplete()
 
-        # 스트리밍 응답
-        async def generate():
-            model = get_chat_model()
-            async for chunk in model.astream(prompt):
-                yield chunk.content
+    # 아직 질문이 남았다면 해당 질문 반환
+    return UBTIQuestion(question=UBTI_QUESTIONS[step], step=step)
 
-        return StreamingResponse(generate(), media_type="text/plain")
+
+@router.post(
+    "/ubti/result",
+    summary="모든 UBTI 답변을 합쳐 최종 결과 JSON으로 반환",
+    response_model=UBTIResult
+)
+async def final_result(req: UBTIRequest):
+    session_id = f"ubti_session:{req.session_id}"
+    session = get_session(session_id)
+    if not session or session["step"] < len(UBTI_QUESTIONS):
+        raise HTTPException(status_code=400, detail="아직 모든 질문이 마무리되지 않았습니다.")
+
+    # 마지막 답변 추가
+    session["answers"].append(req.message)
+    delete_session(session_id)
+
+    # UBTI 유형 & 요금제 정보 로드
+    ubti_types = get_all_ubti_types()
+    plans = get_all_plans()
+    prompt = get_ubti_prompt().format(
+        message="\n".join(session["answers"]),
+        ubti_types="\n".join(f"{u.emoji} {u.code} - {u.name}" for u in ubti_types),
+        plans="\n".join(p.name for p in plans)
+    )
+
+    # LLM 호출해서 스트리밍으로 받고 합침
+    model = get_chat_model()
+    full = ""
+    async for chunk in model.astream(prompt):
+        full += chunk.content
+
+    return UBTIResult(message=full)

--- a/chatbot-server/app/schemas/ubti.py
+++ b/chatbot-server/app/schemas/ubti.py
@@ -1,6 +1,17 @@
-# app/schemas/ubti.py
 from pydantic import BaseModel
+from typing import Optional, Union
 
 class UBTIRequest(BaseModel):
     session_id: str
-    message: str  # 성향 분석용 단일 응답만 받음
+    message: Optional[str] = None
+
+class UBTIQuestion(BaseModel):
+    question: str
+    step: int
+
+class UBTIResult(BaseModel):
+    message: str
+
+class UBTIComplete(BaseModel):
+    completed: bool = True
+    message: str = "모든 질문이 완료되었습니다."


### PR DESCRIPTION
### #️⃣연관된 이슈

<!-- PR과 연관된 이슈 번호를 작성해주세요. -->

> close: #6 

### 🔎 작업 내용


- [x] ubti API 질문 결과 분리를 위한 스키마 수정
  - 기존에 스트리밍 형식으로 합쳐져 있던 ubti API를 수정해서, 
  - 질문만 스트리밍, 결과는 JSON으로 서버에서 뱉도록 합니다.
### 📸 스크린샷

### :loudspeaker: 전달사항

- 추가한 라이브러리나 특이 사항

## ✅ Check List

- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
